### PR TITLE
Fixed wrong check in TcpListener.Stop()

### DIFF
--- a/nanoframework.System.Net.Sockets.TcpClient/Sockets/TcpListener.cs
+++ b/nanoframework.System.Net.Sockets.TcpClient/Sockets/TcpListener.cs
@@ -75,7 +75,7 @@ namespace System.Net.Sockets
         /// </summary>
         public void Stop()
         {
-            if (Active)
+            if (!Active)
             {
                 throw new InvalidOperationException();
             }


### PR DESCRIPTION
## Description
- Should throw an exception when calling Stop() on NOT active listener.
- Typical copy/paste human error

## Motivation and Context
- Because Stop not working properly.

## Types of changes
- [✓ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)

## Checklist:
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
